### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 # can you make it worse? :) 
 RUN apt update && apt install -y python3 python3-pip locales && locale-gen en_US.UTF-8
 ENV        LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Upgrading Python 3.6 to latest version for solving "Python3.6 AttributeError: module 'asyncio' has no attribute 'run'" problem.